### PR TITLE
Cookie Consent: Aufruf einer Callback-Funktion jetzt möglich

### DIFF
--- a/fragments/dsgvo-consent.fragment.inc.php
+++ b/fragments/dsgvo-consent.fragment.inc.php
@@ -6,7 +6,7 @@
 				<p class="dsgvo-cookie_consent-text"><?= $this->info; ?> <a class="dsgvo-cookie_consent-more" href="<?= $this->url; ?>"><?= $this->learn_more; ?></a></p>
 			</div>
 			<div class="dsgvo-cookie_consent-dismiss">
-				<button class="dsgvo-cookie_consent-ok" onClick="dsgvoConsent(1);"><?= $this->dismiss; ?></button>
+				<button class="dsgvo-cookie_consent-ok" onClick="dsgvoConsent(1);<?= $this->dismiss_callback; ?>;"><?= $this->dismiss; ?></button>
 			</div>
 		</div>
 	</div>

--- a/pages/dsgvo.consent.php
+++ b/pages/dsgvo.consent.php
@@ -63,6 +63,7 @@ $output = new rex_fragment();
 $output->setVar("info", "Um unsere Webseite für Sie optimal zu gestalten und fortlaufend verbessern zu können, verwenden wir Cookies. Durch die weitere Nutzung der Webseite stimmen Sie der Verwendung von Cookies zu. Weitere Informationen zu Cookies erhalten Sie in unserer");
 $output->setVar("learn_more", "Datenschutzerklärung");
 $output->setVar("dismiss", "OK");
+$output->setVar("dismiss_callback", "meine_callback_funktion()"); // wenn keine Callback-Funktion benötigt wird, einfach einen Leerwert "" übergeben
 $output->setVar("url", "/datenschutz/");
 $output->setVar("html_padding", "Bottom");
 echo $output->parse("dsgvo-consent.fragment.inc.php");

--- a/pages/dsgvo.setup.overview.php
+++ b/pages/dsgvo.setup.overview.php
@@ -48,6 +48,7 @@ $output = new rex_fragment();
 $output->setVar("info", "Um unsere Webseite für Sie optimal zu gestalten und fortlaufend verbessern zu können, verwenden wir Cookies. Durch die weitere Nutzung der Webseite stimmen Sie der Verwendung von Cookies zu. Weitere Informationen zu Cookies erhalten Sie in unserer");
 $output->setVar("learn_more", "Datenschutzerklärung");
 $output->setVar("dismiss", "OK");
+$output->setVar("dismiss_callback", "meine_callback_funktion()"); // wenn keine Callback-Funktion benötigt wird, einfach einen Leerwert "" übergeben
 $output->setVar("url", "/datenschutz/");
 $output->setVar("html_padding", "Bottom");
 echo $output->parse("dsgvo-consent.fragment.inc.php");
@@ -70,4 +71,3 @@ echo $output->parse("dsgvo-consent.fragment.inc.php");
     echo $fragment->parse('core/page/section.php');
         
 }
-

--- a/plugins/server/standalone/dsgvo/dsgvo-consent.inc.php
+++ b/plugins/server/standalone/dsgvo/dsgvo-consent.inc.php
@@ -1,10 +1,11 @@
 <?php
 
-$consent['info']            = "Um unsere Webseite für Sie optimal zu gestalten und fortlaufend verbessern zu können, verwenden wir Cookies. Durch die weitere Nutzung der Webseite stimmen Sie der Verwendung von Cookies zu. Weitere Informationen zu Cookies erhalten Sie in unserer";
-$consent['more']            = "Datenschutzerklärung.";
-$consent['dismiss']         = "OK";
-$consent['url']             = "/datenschutz.php";
-$consent['html_padding']    = "Bottom";
+$consent['info']             = "Um unsere Webseite für Sie optimal zu gestalten und fortlaufend verbessern zu können, verwenden wir Cookies. Durch die weitere Nutzung der Webseite stimmen Sie der Verwendung von Cookies zu. Weitere Informationen zu Cookies erhalten Sie in unserer";
+$consent['more']             = "Datenschutzerklärung.";
+$consent['dismiss']          = "OK";
+$consent['dismiss_callback'] = "";  // bzw. Funktion übergeben "meine_callback_funktion()";
+$consent['url']              = "/datenschutz.php";
+$consent['html_padding']     = "Bottom";
 
 echo getDsgvoConsent($consent);
 ?>

--- a/plugins/server/standalone/dsgvo/dsgvo-consent.tpl.php
+++ b/plugins/server/standalone/dsgvo/dsgvo-consent.tpl.php
@@ -5,7 +5,7 @@
 				<p class="dsgvo-cookie_consent-text"><?= $this->consent['info']; ?> <a class="dsgvo-cookie_consent-more" href="<?= $this->consent['url']; ?>"><?= $this->consent['more']; ?></a></p>
 			</div>
 			<div class="dsgvo-cookie_consent-dismiss">
-				<button class="dsgvo-cookie_consent-ok" onClick="dsgvoConsent(1);"><?= $this->consent['dismiss']; ?></button>
+				<button class="dsgvo-cookie_consent-ok" onClick="dsgvoConsent(1);<?= $this->consent['dismiss_callback']; ?>;"><?= $this->consent['dismiss']; ?></button>
 			</div>
 		</div>
 	<script>

--- a/plugins/server/standalone/standalone.php
+++ b/plugins/server/standalone/standalone.php
@@ -6,13 +6,12 @@ echo getTrackingCodes("de", "example.com");
 
 echo getDsgvoPage("de", "example.com");
 
-$consent['info']       			 = "Um unsere Webseite für Sie optimal zu gestalten und fortlaufend verbessern zu können, verwenden wir Cookies. Durch die weitere Nutzung der Webseite stimmen Sie der Verwendung von Cookies zu. Weitere Informationen zu Cookies erhalten Sie in unserer";
-$consent['more']       			 = "Datenschutzerklärung.";
-$consent['dismiss']    			 = "OK";
+$consent['info']             = "Um unsere Webseite für Sie optimal zu gestalten und fortlaufend verbessern zu können, verwenden wir Cookies. Durch die weitere Nutzung der Webseite stimmen Sie der Verwendung von Cookies zu. Weitere Informationen zu Cookies erhalten Sie in unserer";
+$consent['more']             = "Datenschutzerklärung.";
+$consent['dismiss']          = "OK";
 $consent['dismiss_callback'] = ""; // bzw. Funktion übergeben "meine_callback_funktion()";
-$consent['url']        			 = "/datenschutz/";
+$consent['url']              = "/datenschutz/";
 
 echo getDsgvoConsent($consent);
-
 
 ?>

--- a/plugins/server/standalone/standalone.php
+++ b/plugins/server/standalone/standalone.php
@@ -6,10 +6,11 @@ echo getTrackingCodes("de", "example.com");
 
 echo getDsgvoPage("de", "example.com");
 
-$consent['info']       = "Um unsere Webseite für Sie optimal zu gestalten und fortlaufend verbessern zu können, verwenden wir Cookies. Durch die weitere Nutzung der Webseite stimmen Sie der Verwendung von Cookies zu. Weitere Informationen zu Cookies erhalten Sie in unserer";
-$consent['more']       = "Datenschutzerklärung.";
-$consent['dismiss']    = "OK";
-$consent['url']        = "/datenschutz/";
+$consent['info']       			 = "Um unsere Webseite für Sie optimal zu gestalten und fortlaufend verbessern zu können, verwenden wir Cookies. Durch die weitere Nutzung der Webseite stimmen Sie der Verwendung von Cookies zu. Weitere Informationen zu Cookies erhalten Sie in unserer";
+$consent['more']       			 = "Datenschutzerklärung.";
+$consent['dismiss']    			 = "OK";
+$consent['dismiss_callback'] = ""; // bzw. Funktion übergeben "meine_callback_funktion()";
+$consent['url']        			 = "/datenschutz/";
 
 echo getDsgvoConsent($consent);
 


### PR DESCRIPTION
Es ist nun mit dem Klick auf die Dismiss-Schaltfläche möglich eine Callback-Funktion aufzurufen.
`$dsgvo->setVar("dismiss_callback", "meine_callback_funktion()");`

Hinweis: Die selbst definierte und aufgerufene Funktion muss natürlich manuell eingebunden werden (zum Beispiel hart codiert  im Template)...